### PR TITLE
Add big_key support

### DIFF
--- a/ref.go
+++ b/ref.go
@@ -122,7 +122,7 @@ func (r *Reference) Get() (Id, error) {
 	}
 
 	switch r.info.Type {
-	case "key":
+	case "key", "big_key":
 		return &Key{Name: r.info.Name, id: keyId(r.Id), ring: r.parent}, nil
 	case "keyring":
 		ring := &keyring{id: keyId(r.Id)}


### PR DESCRIPTION
This enables reading the krb5 ccache

    info, err := k.Info()
    ... info.Type == "big_key"
    id, err := k.Get()
    key, ok := id.(*keyctl.Key)
    data, err := key.Get()