### PR TITLE
Implement Link operation

### DIFF
--- a/keyring.go
+++ b/keyring.go
@@ -181,7 +181,7 @@ func SetKeyringTTL(kr NamedKeyring, nsecs uint) error {
 
 // Unlink an object from a keyring
 func Unlink(parent Keyring, child Id) error {
-	return keyctl_Unlink(keyId(parent.Id()), keyId(child.Id()))
+	return keyctl_Unlink(keyId(child.Id()), keyId(parent.Id()))
 }
 
 // Unlink a named keyring from its parent.

--- a/keyring.go
+++ b/keyring.go
@@ -179,6 +179,11 @@ func SetKeyringTTL(kr NamedKeyring, nsecs uint) error {
 	return err
 }
 
+// Link an object to a keyring
+func Link(parent Keyring, child Id) error {
+	return keyctl_Link(keyId(child.Id()), keyId(parent.Id()))
+}
+
 // Unlink an object from a keyring
 func Unlink(parent Keyring, child Id) error {
 	return keyctl_Unlink(keyId(child.Id()), keyId(parent.Id()))

--- a/sys_linux.go
+++ b/sys_linux.go
@@ -102,6 +102,14 @@ func keyctl_Read(id keyId, b *byte, size int) (int32, error) {
 	return int32(v1), nil
 }
 
+func keyctl_Link(id, ring keyId) error {
+	_, _, errno := syscall.Syscall(syscall_keyctl, uintptr(keyctlLink), uintptr(id), uintptr(ring))
+	if errno != 0 {
+		return errno
+	}
+	return nil
+}
+
 func keyctl_Unlink(id, ring keyId) error {
 	_, _, errno := syscall.Syscall(syscall_keyctl, uintptr(keyctlUnlink), uintptr(id), uintptr(ring))
 	if errno != 0 {


### PR DESCRIPTION
This PR implements the `Link()` operation and its underlying syscall to be able to link keys and keyrings to other keyrings. This is necessary if you want to e.g. link a key to multiple keyrings or for moving keys and keyrings between keyrings.

See the [keyctl manpage}(https://man7.org/linux/man-pages/man3/keyctl_link.3.html) for details.

I the course, we now have the means to solve the permission denied problem in #6 which is cased by non-modifiable standard permissions when dealing with the user-session keyring (details in issue #6).
Furthermore, the PR fixes the wrong argument order for `Unlink()` leading to `ENODIR` errors.

resolves #6 